### PR TITLE
Add initial setup for the Kustomer client

### DIFF
--- a/lib/generators/solidus_kustomer/install/templates/initializer.rb
+++ b/lib/generators/solidus_kustomer/install/templates/initializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+SolidusKustomer.configure do |config|
+  # Your Kustomer API key, in order to communicate with the Kustomer API.
+  config.api_key = 'YOUR_KUSTOMER_API_KEY'
+end

--- a/lib/solidus_kustomer.rb
+++ b/lib/solidus_kustomer.rb
@@ -1,7 +1,24 @@
 # frozen_string_literal: true
 
+require 'httparty'
 require 'solidus_core'
 require 'solidus_support'
+require 'solidus_tracking'
 
 require 'solidus_kustomer/version'
 require 'solidus_kustomer/engine'
+require 'solidus_kustomer/configuration'
+require 'solidus_kustomer/errors'
+require 'solidus_kustomer/client'
+
+module SolidusKustomer
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield configuration
+    end
+  end
+end

--- a/lib/solidus_kustomer/client.rb
+++ b/lib/solidus_kustomer/client.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module SolidusKustomer
+  class Client
+    class << self
+      def from_config
+        new(api_key: SolidusKustomer.configuration.api_key)
+      end
+    end
+
+    def initialize(api_key:, url: 'https://api.kustomerapp.com/v1/')
+      @api_key = api_key
+      @url = url
+    end
+
+    # Create a new instance of a Kustomer Klass for a customer
+    #
+    # @param kobject_klass [String] the Klass name of the KObject to create
+    # @param customer [Spree::User] the user whose id will own the created KObject
+    #
+    # @return [Boolean] whether the creation succeded or not
+    def create(kobject_klass, attributes:, customer:)
+      customer_id = find_customer_by_external_id(customer)['id']
+
+      response = HTTParty.post(
+        "#{@url}customers/#{customer_id}/klasses/#{kobject_klass}",
+        body: {
+          title: kobject_klass.capitalize,
+          custom: attributes
+        }.to_json,
+        headers: headers
+      )
+
+      response.success? || raise(SolidusKustomer::CreateError)
+    end
+
+    # Finds the customer via the Solidus database id
+    #
+    # @param user [Spree::User] the user whose data we're looking for
+    #
+    # @return [Hash] the customer data
+    def find_customer_by_external_id(user)
+      response = HTTParty.get(
+        "#{@url}customers/externalId=#{user.id}",
+        headers: headers
+      )
+
+      response.parsed_response['data'] if response.success?
+    end
+
+    private
+
+    def headers
+      {
+        'Authorization' => "Bearer #{@api_key}",
+        'Content-Type' => 'application/json'
+      }
+    end
+  end
+end

--- a/lib/solidus_kustomer/configuration.rb
+++ b/lib/solidus_kustomer/configuration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SolidusKustomer
+  class Configuration
+    attr_accessor :api_key
+  end
+end

--- a/lib/solidus_kustomer/errors.rb
+++ b/lib/solidus_kustomer/errors.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module SolidusKustomer
+  class CreateError < RuntimeError; end
+  class NotFoundError < RuntimeError; end
+end

--- a/solidus_kustomer.gemspec
+++ b/solidus_kustomer.gemspec
@@ -32,5 +32,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
+  spec.add_dependency 'httparty', '~> 0.18'
+  spec.add_dependency 'solidus_tracking', '~> 0.0'
+
   spec.add_development_dependency 'solidus_dev_support', '~> 2.0'
+  spec.add_development_dependency 'vcr'
+  spec.add_development_dependency 'webmock'
 end

--- a/spec/fixtures/vcr_cassettes/create_failure.yml
+++ b/spec/fixtures/vcr_cassettes/create_failure.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.kustomerapp.com/v1/customers/the_customer_UUID/klasses/order
+    body:
+      encoding: UTF-8
+      string: '{"title":"Order","custom":{"notAnActualAttribute":"foobar"}}'
+    headers:
+      Authorization:
+      - Bearer my_api_key
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '186'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 01 Oct 2020 12:25:07 GMT
+      Vary:
+      - X-HTTP-Method-Override, Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Kustomer-Pod:
+      - prod1
+      Timing-Allow-Origin:
+      - "*"
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '999'
+      Cache-Control:
+      - no-cache,private
+      Etag:
+      - W/"ba-pxrU3oVoK4AvG2e1Dxgp7p2M41U"
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 6f6484aa8a9f0cd7156cc9e6f320c8f2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MXP64-C3
+      X-Amz-Cf-Id:
+      - JtWJQRfVFs2oNXaygYQPMZzjy5S5SPKRTekHju1qt794Cg2WYiyPMA==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"status":400,"source":{"parameter":"notAnActualAttribute"},"code":"badparam","title":"Additional
+        properties not allowed","detail":"/properties/custom/additionalProperties"}]}'
+  recorded_at: Thu, 01 Oct 2020 12:25:07 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/create_success.yml
+++ b/spec/fixtures/vcr_cassettes/create_success.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.kustomerapp.com/v1/customers/the_customer_UUID/klasses/order
+    body:
+      encoding: UTF-8
+      string: '{"title":"Order","custom":{"orderIdNum":1,"orderCreatedAt":"2020-10-01T12:06:19.825Z","orderNumberStr":"R11111111"}}'
+    headers:
+      Authorization:
+      - Bearer my_api_key
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '753'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 01 Oct 2020 12:06:20 GMT
+      Vary:
+      - X-HTTP-Method-Override, Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Kustomer-Pod:
+      - prod1
+      Timing-Allow-Origin:
+      - "*"
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '999'
+      Cache-Control:
+      - no-cache,private
+      Etag:
+      - W/"2f1-Gv28M9fZUJj/84h39VT6GQqfI0E"
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 2fb101a75d62357647d00a936fb26d03.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MXP64-C3
+      X-Amz-Cf-Id:
+      - Wly-4QAZHuwHqQbGdjzbjCVXJWRs9oLq9WNTSzluHYrrzRZRVFNfxQ==
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"kobject.order","id":"5f75c63cd5c0384ad82a17ae","attributes":{"title":"Order","icon":"shopping","images":[],"custom":{"orderIdNum":1,"orderCreatedAt":"2020-10-01T12:06:19.825Z","orderNumberStr":"R11111111"},"tags":[],"updatedAt":"2020-10-01T12:06:20.291Z","createdAt":"2020-10-01T12:06:20.291Z","rev":1,"roleGroupVersions":[]},"relationships":{"org":{"links":{"self":"/v1/orgs/5f651b02c887b30019382410"},"data":{"type":"org","id":"5f651b02c887b30019382410"}},"klass":{"link":{"self":"/v1/klasses/order"},"data":{"type":"klass","id":"order"}},"customer":{"links":{"self":"/v1/customers/the_customer_UUID"},"data":{"type":"customer","id":"the_customer_UUID"}}},"links":{"self":"/v1/klasses/orders/5f75c63cd5c0384ad82a17ae"}}}'
+  recorded_at: Thu, 01 Oct 2020 12:06:20 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/find_failure.yml
+++ b/spec/fixtures/vcr_cassettes/find_failure.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.kustomerapp.com/v1/customers/externalId=9999
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer my_api_key
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '101'
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 01 Oct 2020 15:10:09 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Kustomer-Pod:
+      - prod1
+      Timing-Allow-Origin:
+      - "*"
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '999'
+      Cache-Control:
+      - no-cache,private
+      Etag:
+      - W/"65-s+40w1cIGBGcdpolCOY90Z+5vq0"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 c80e676948368625bab1e3de26dbd163.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MXP64-C3
+      X-Amz-Cf-Id:
+      - zNXDle3WbdWmuL-LDL7UonFY9cLzH2ENt9Za1Xv10jyPnpKSExQTxA==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"status":404,"source":{"parameter":"externalId"},"code":"notfound","title":"Not
+        Found"}]}'
+  recorded_at: Thu, 01 Oct 2020 15:10:09 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/find_success.yml
+++ b/spec/fixtures/vcr_cassettes/find_success.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.kustomerapp.com/v1/customers/externalId=6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer my_api_key
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Thu, 01 Oct 2020 15:07:56 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Kustomer-Pod:
+      - prod1
+      Timing-Allow-Origin:
+      - "*"
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '999'
+      Cache-Control:
+      - no-cache,private
+      Etag:
+      - W/"947-FzNXMUWrQo/0BhG/7yKhFbmM+N4"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 92f3f87cb514c53ec6a2ae134f3e13a2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MXP64-C3
+      X-Amz-Cf-Id:
+      - t7sOaKXoqPrdTgFmFD4dZ_1l3n4JirJ--yAIz0yxdSbI7Ha2C_vtTQ==
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"type":"customer","id":"the_customer_UUID","attributes":{"name":"","displayName":"johndoe@example.com","displayColor":"blue","displayIcon":"plane","externalId":"6","externalIds":[{"verified":true,"externalId":"6"}],"sharedExternalIds":[],"signedUpAt":"2020-09-28T12:53:04.000Z","username":"johndoe@example.com","emails":[{"type":"home","verified":false,"email":"johndoe@example.com"}],"sharedEmails":[],"phones":[],"sharedPhones":[],"smoochIds":[],"whatsapps":[],"facebookIds":[],"instagramIds":[],"socials":[],"sharedSocials":[],"urls":[],"locations":[],"activeUsers":[],"watchers":[],"recentLocation":{"updatedAt":"2020-09-28T12:53:23.176Z"},"createdAt":"2020-09-28T12:53:23.175Z","updatedAt":"2020-10-01T12:06:20.291Z","modifiedAt":"2020-09-28T12:58:25.555Z","lastActivityAt":"2020-10-01T12:06:20.291Z","lastCustomerActivityAt":"2020-10-01T12:06:20.291Z","deleted":false,"lastMessageIn":{"sentiment":{}},"lastMessageOut":{},"lastMessageUnrespondedTo":{},"lastConversation":{"sentiment":{},"channels":[],"tags":[]},"conversationCounts":{"done":0,"open":0,"snoozed":0,"all":0},"preview":{"$init":true},"tags":[],"sentiment":{},"progressiveStatus":null,"verified":true,"rev":35,"recentItems":[{"meta":{"klassName":"order"},"updatedAt":"2020-10-01T12:06:20.291Z","type":"kobject","id":"5f75c63cd5c0384ad82a17ae"},{"meta":{"klassName":"order"},"updatedAt":"2020-10-01T08:29:42.476Z","type":"kobject","id":"5f7593766df85173b7f96d8a"},{"meta":{"klassName":"order"},"updatedAt":"2020-10-01T08:00:31.521Z","type":"kobject","id":"5f758c9fd5c0381f1a261d61"},{"meta":{"klassName":"order"},"updatedAt":"2020-09-30T16:14:27.048Z","type":"kobject","id":"5f74aee3133e7b0012afee85"}],"satisfactionLevel":{"firstSatisfaction":{"sentByTeams":[]},"lastSatisfaction":{"sentByTeams":[]}},"roleGroupVersions":[],"accessOverride":[]},"relationships":{"messages":{"links":{"self":"/v1/customers/the_customer_UUID/messages"}},"modifiedBy":{"links":{"self":"/v1/users/5f652db64624d3001950caff"},"data":{"type":"user","id":"5f652db64624d3001950caff"}},"org":{"data":{"type":"org","id":"5f651b02c887b30019382410"},"links":{"self":"/v1/orgs/5f651b02c887b30019382410"}},"orders":{"links":{"self":"/v1/customers/the_customer_UUID/klasses/orders"},"meta":{"kobject":true}}},"links":{"self":"/v1/customers/the_customer_UUID"}}}'
+  recorded_at: Thu, 01 Oct 2020 15:07:56 GMT
+recorded_with: VCR 6.0.0

--- a/spec/lib/solidus_kustomer/client_spec.rb
+++ b/spec/lib/solidus_kustomer/client_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+RSpec.describe SolidusKustomer::Client do
+  describe '#headers' do
+    it 'returns the headers with the expected parameters' do
+      kustomer = described_class.new(api_key: 'my_api_key')
+
+      headers = kustomer.send(:headers)
+
+      expect(headers).to include(
+        'Authorization' => 'Bearer my_api_key',
+        'Content-Type' => 'application/json'
+      )
+    end
+  end
+
+  describe '#create' do
+    context 'with well-formed custom attributes' do
+      it 'creates the KObject for the customer' do
+        kustomer = described_class.new(api_key: 'my_api_key')
+        user = build_stubbed(:user)
+        attributes = {
+          'orderIdNum' => 1,
+          'orderCreatedAt' => Time.zone.now,
+          'orderNumberStr' => 'R11111111'
+        }
+        allow(kustomer).to receive(:find_customer_by_external_id)
+          .with(user)
+          .and_return(
+            {
+              'type' => 'customer',
+              'id' => 'the_customer_UUID',
+              'attributes' => {
+                'username' => 'johndoe@example.com',
+                'externalId' => user.id
+              }
+            }
+          )
+
+        VCR.use_cassette('create_success') do
+          kustomer.create('order', attributes: attributes, customer: user)
+        end
+
+        expect(
+          a_request(:post, "https://api.kustomerapp.com/v1/customers/the_customer_UUID/klasses/order")
+        ).to have_been_made
+      end
+    end
+
+    context 'with malformed custom attributes' do
+      it 'raises a CreateError' do
+        kustomer = described_class.new(api_key: 'my_api_key')
+        user = build_stubbed(:user)
+        attributes = {
+          'notAnActualAttribute' => 'foobar'
+        }
+        allow(kustomer).to receive(:find_customer_by_external_id)
+          .with(user)
+          .and_return(
+            {
+              'type' => 'customer',
+              'id' => 'the_customer_UUID',
+              'attributes' => {
+                'username' => 'johndoe@example.com',
+                'externalId' => user.id
+              }
+            }
+          )
+
+        VCR.use_cassette('create_failure') do
+          expect {
+            kustomer.create('order', attributes: attributes, customer: user)
+          }.to raise_error(SolidusKustomer::CreateError)
+        end
+      end
+    end
+  end
+
+  describe '#find_customer_by_external_id' do
+    context 'when querying for an existing customer' do
+      it 'returns the customer KObject as an hash' do
+        kustomer = described_class.new(api_key: 'my_api_key')
+        user = build_stubbed(:user, id: 6)
+
+        VCR.use_cassette('find_success') do
+          customer = kustomer.find_customer_by_external_id(user)
+          expect(customer).to include(
+            'id' => 'the_customer_UUID',
+            'type' => 'customer'
+          )
+        end
+      end
+    end
+
+    context 'when querying for a non existent customer' do
+      it 'returns nil' do
+        kustomer = described_class.new(api_key: 'my_api_key')
+        user = build_stubbed(:user, id: 9999)
+
+        VCR.use_cassette('find_failure') do
+          customer = kustomer.find_customer_by_external_id(user)
+          expect(customer).to eq(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'webmock'
+require 'webmock/rspec'
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end


### PR DESCRIPTION
This PR lays the groundwork to build upon for implementing further customization of the extension. After merging it it will provide functionality for:

- finding a Kustomer customer UUID via its solidus `Spree::User` `id` (in Kustomer lingo the `externalId`)
- creating arbitrary `KObjects` for a customer for whom is knows their `UUID` and Klasses are defined in the Kustomer organization