### PR TITLE
Add customer management

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,21 @@ The events tracked by default are:
 
 - `order_finalized`
 
-### Creating customers on Kustomer
+### Customer lifecycle
 
-If you want to automatically create a customer on the Kustomer app upon account creation, you can
-set the `identify_customer_on_creation` configuration flag to `true`:
+The extension default configurations is set to create and update customers every time a user is
+created or updated. If you want to disable this behaviour, delete or set the following configuration
+options to false:
 
 ```ruby
 # config/initializers/solidus_kustomer.rb
 
 SolidusKustomer.configure do |config|
   # ...
-  config.identify_customer_on_creation = true
+  config.create_customer_on_user_creation = true
+  config.update_customer_on_user_update = true
 end
 ```
-
-Newly created users will be automatically identified (registered as customers) on Kustomer.
 
 ## Development
 

--- a/app/decorators/models/solidus_kustomer/spree/user/kustomer_lifecycle.rb
+++ b/app/decorators/models/solidus_kustomer/spree/user/kustomer_lifecycle.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module SolidusKustomer
+  module Spree
+    module User
+      module KustomerLifecycle
+        def self.prepended(base)
+          base.after_commit :create_customer_on_creation, on: :create
+          base.after_commit :update_customer_on_update, on: :update
+        end
+
+        private
+
+        def create_customer_on_creation
+          return unless SolidusKustomer.configuration.create_customer_on_user_creation
+
+          SolidusKustomer.create_customer_later(self)
+        end
+
+        def update_customer_on_update
+          return unless SolidusKustomer.configuration.update_customer_on_user_update
+
+          SolidusKustomer.update_customer_later(self)
+        end
+      end
+    end
+  end
+end
+
+Spree.user_class.prepend(SolidusKustomer::Spree::User::KustomerLifecycle)

--- a/app/jobs/solidus_kustomer/create_customer_job.rb
+++ b/app/jobs/solidus_kustomer/create_customer_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusKustomer
+  class CreateCustomerJob < ApplicationJob
+    queue_as :default
+
+    def perform(user)
+      SolidusKustomer.create_customer_now(user)
+    end
+  end
+end

--- a/app/jobs/solidus_kustomer/update_customer_job.rb
+++ b/app/jobs/solidus_kustomer/update_customer_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusKustomer
+  class UpdateCustomerJob < ApplicationJob
+    queue_as :default
+
+    def perform(user)
+      SolidusKustomer.update_customer_now(user)
+    end
+  end
+end

--- a/db/migrate/20201001065311_add_kustomer_id_to_users.rb
+++ b/db/migrate/20201001065311_add_kustomer_id_to_users.rb
@@ -1,0 +1,6 @@
+class AddKustomerIdToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :spree_users, :kustomer_id, :string
+    add_index :spree_users, :kustomer_id
+  end
+end

--- a/lib/generators/solidus_kustomer/install/templates/initializer.rb
+++ b/lib/generators/solidus_kustomer/install/templates/initializer.rb
@@ -3,4 +3,8 @@
 SolidusKustomer.configure do |config|
   # Your Kustomer API key, in order to communicate with the Kustomer API.
   config.api_key = 'YOUR_KUSTOMER_API_KEY'
+
+  # These options enable automatic customer lifecycle tracking for users on Kustomer.
+  config.create_customer_on_user_creation = true
+  config.update_customer_on_user_update = true
 end

--- a/lib/solidus_kustomer.rb
+++ b/lib/solidus_kustomer.rb
@@ -22,5 +22,27 @@ module SolidusKustomer
     def configure
       yield configuration
     end
+
+    def create_customer_now(user)
+      kustomer_client.create_customer(user)
+    end
+
+    def create_customer_later(user)
+      SolidusKustomer::CreateCustomerJob.perform_later(user)
+    end
+
+    def update_customer_now(user)
+      kustomer_client.update_customer(user)
+    end
+
+    def update_customer_later(user)
+      SolidusKustomer::UpdateCustomerJob.perform_later(user)
+    end
+
+    private
+
+    def kustomer_client
+      @kustomer_client ||= SolidusKustomer::Client.new(api_key: configutation.api_key)
+    end
   end
 end

--- a/lib/solidus_kustomer.rb
+++ b/lib/solidus_kustomer.rb
@@ -10,6 +10,8 @@ require 'solidus_kustomer/engine'
 require 'solidus_kustomer/configuration'
 require 'solidus_kustomer/errors'
 require 'solidus_kustomer/client'
+require 'solidus_kustomer/serializer/base'
+require 'solidus_kustomer/serializer/user'
 
 module SolidusKustomer
   class << self

--- a/lib/solidus_kustomer/client.rb
+++ b/lib/solidus_kustomer/client.rb
@@ -27,7 +27,9 @@ module SolidusKustomer
 
       raise(SolidusKustomer::CustomerCreateError) unless response.success?
 
-      user.update!(kustomer_id: response.parsed_response['data']['id'])
+      # rubocop:disable Rails/SkipsModelValidations
+      user.update_column(:kustomer_id, response.parsed_response['data']['id'])
+      # rubocop:enable Rails/SkipsModelValidations
       response.parsed_response['data']
     end
 
@@ -82,7 +84,9 @@ module SolidusKustomer
       return find_customer_by_uuid(user.kustomer_id) if user.kustomer_id
 
       customer = find_customer_by_email(user.email) || find_customer_by_external_id(user.id)
-      user.update!(kustomer_id: customer['id']) if customer
+      # rubocop:disable Rails/SkipsModelValidations
+      user.update_column(:kustomer_id, customer['id']) if customer
+      # rubocop:enable Rails/SkipsModelValidations
       customer
     end
 
@@ -96,7 +100,9 @@ module SolidusKustomer
       return user.kustomer_id if user.kustomer_id
 
       customer = find_customer(user)
-      user.update!(kustomer_id: customer['id']) if customer
+      # rubocop:disable Rails/SkipsModelValidations
+      user.update_column(:kustomer_id, customer['id']) if customer
+      # rubocop:enable Rails/SkipsModelValidations
       customer['id']
     end
 

--- a/lib/solidus_kustomer/client.rb
+++ b/lib/solidus_kustomer/client.rb
@@ -13,6 +13,44 @@ module SolidusKustomer
       @url = url
     end
 
+    # Creates a new customer on Kustomer
+    #
+    # @param user [Spree::User] the user to create on Kustomer
+    #
+    # @return [Hash] containing the newly created data on Kustomer
+    def create_customer(user)
+      response = HTTParty.post(
+        "#{@url}customers",
+        body: SolidusKustomer::Serializer::User.serialize(user).to_json,
+        headers: headers
+      )
+
+      raise(SolidusKustomer::CustomerCreateError) unless response.success?
+
+      user.update!(kustomer_id: response.parsed_response['data']['id'])
+      response.parsed_response['data']
+    end
+
+    # Updates a customer on Kustomer
+    #
+    # @param user [Spree::User] the user to update on Kustomer
+    #
+    # @return [Hash] containing the updated Kustomer data or nil
+    # if it attempts to update a customer without a kustomer_id
+    def update_customer(user)
+      return unless user.kustomer_id
+
+      response = HTTParty.put(
+        "#{@url}customers/#{user.kustomer_id}",
+        body: SolidusKustomer::Serializer::User.serialize(user).to_json,
+        headers: headers
+      )
+
+      raise(SolidusKustomer::CustomerUpdateError) unless response.success?
+
+      response.parsed_response['data']
+    end
+
     # Create a new instance of a Kustomer Klass for a customer
     #
     # @param kobject_klass [String] the Klass name of the KObject to create

--- a/lib/solidus_kustomer/configuration.rb
+++ b/lib/solidus_kustomer/configuration.rb
@@ -2,6 +2,6 @@
 
 module SolidusKustomer
   class Configuration
-    attr_accessor :api_key
+    attr_accessor :api_key, :create_customer_on_user_creation, :update_customer_on_user_update
   end
 end

--- a/lib/solidus_kustomer/errors.rb
+++ b/lib/solidus_kustomer/errors.rb
@@ -2,5 +2,7 @@
 
 module SolidusKustomer
   class CreateError < RuntimeError; end
+  class CustomerCreateError < RuntimeError; end
+  class CustomerUpdateError < RuntimeError; end
   class NotFoundError < RuntimeError; end
 end

--- a/lib/solidus_kustomer/serializer/base.rb
+++ b/lib/solidus_kustomer/serializer/base.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module SolidusKustomer
+  module Serializer
+    class Base
+      attr_reader :object
+
+      def initialize(object)
+        @object = object
+      end
+
+      class << self
+        def serialize(object)
+          new(object).as_json
+        end
+      end
+
+      def as_json(_options = {})
+        raise NotImplementedError
+      end
+
+      def custom_attributes
+        {}
+      end
+    end
+  end
+end

--- a/lib/solidus_kustomer/serializer/user.rb
+++ b/lib/solidus_kustomer/serializer/user.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SolidusKustomer
+  module Serializer
+    class User < SolidusKustomer::Serializer::Base
+      def user
+        object
+      end
+
+      def as_json
+        {
+          'name' => name_builder(user.bill_address || user.ship_address),
+          'username': user.email,
+          'emails' => [
+            {
+              'type' => 'home',
+              'email' => user.email,
+            },
+          ],
+          'externalId' => user.id.to_s,
+        }.merge(custom_attributes).compact
+      end
+
+      private
+
+      def name_builder(address)
+        return unless address
+
+        address.respond_to?(:name) ? address.name : "#{address.first_name} #{address.last_name}"
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/create_customer.yml
+++ b/spec/fixtures/vcr_cassettes/create_customer.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.kustomerapp.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: '{"name":"John Von Doe","username":"test500@example.com","emails":[{"type":"home","email":"test500@example.com"}],"externalId":"500"}'
+    headers:
+      Authorization:
+      - Bearer my_api_key
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 06 Oct 2020 14:35:19 GMT
+      Vary:
+      - X-HTTP-Method-Override, Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Kustomer-Pod:
+      - prod1
+      Timing-Allow-Origin:
+      - "*"
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '998'
+      Cache-Control:
+      - no-cache,private
+      Etag:
+      - W/"6a8-NA6gXVq9s4158MQLiJ4dfazaV+A"
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a7750b04e96e89c0816616ed8cc70afc.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MXP64-C3
+      X-Amz-Cf-Id:
+      - jNe059tKku4vWGUKgee0JD7OZBPvbuHh6Nk7eTyvNwvbzflhRcha4g==
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"type":"customer","id":"5f7c80a713ba8c10ff3f2f6f","attributes":{"name":"John
+        Von Doe","displayName":"John Von Doe","displayColor":"teal","displayIcon":"cloud","externalId":"500","externalIds":[{"verified":true,"externalId":"500"}],"sharedExternalIds":[],"username":"test500@example.com","emails":[{"type":"home","verified":false,"email":"test500@example.com"}],"sharedEmails":[],"phones":[],"sharedPhones":[],"smoochIds":[],"whatsapps":[],"facebookIds":[],"instagramIds":[],"socials":[],"sharedSocials":[],"urls":[],"locations":[],"activeUsers":[],"watchers":[],"recentLocation":{"updatedAt":"2020-10-06T14:35:19.066Z"},"createdAt":"2020-10-06T14:35:19.064Z","updatedAt":"2020-10-06T14:35:19.064Z","modifiedAt":"2020-10-06T14:35:19.064Z","lastActivityAt":"2020-10-06T14:35:19.064Z","deleted":false,"lastConversation":{"channels":[],"tags":[]},"conversationCounts":{"done":0,"open":0,"snoozed":0,"all":0},"preview":{},"tags":[],"progressiveStatus":null,"verified":true,"rev":1,"recentItems":[],"satisfactionLevel":{"firstSatisfaction":{"sentByTeams":[]},"lastSatisfaction":{"sentByTeams":[]}},"roleGroupVersions":[],"accessOverride":[],"firstName":"John","lastName":"Von
+        Doe"},"relationships":{"messages":{"links":{"self":"/v1/customers/5f7c80a713ba8c10ff3f2f6f/messages"}},"createdBy":{"links":{"self":"/v1/users/5f7580902bf93344d8e55eda"},"data":{"type":"user","id":"5f7580902bf93344d8e55eda"}},"modifiedBy":{"links":{"self":"/v1/users/5f7580902bf93344d8e55eda"},"data":{"type":"user","id":"5f7580902bf93344d8e55eda"}},"org":{"data":{"type":"org","id":"5f651b02c887b30019382410"},"links":{"self":"/v1/orgs/5f651b02c887b30019382410"}}},"links":{"self":"/v1/customers/5f7c80a713ba8c10ff3f2f6f"}}}'
+  recorded_at: Tue, 06 Oct 2020 14:35:19 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/find_by_email_failure.yml
+++ b/spec/fixtures/vcr_cassettes/find_by_email_failure.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.kustomerapp.com/v1/customers/email=not_a_customer@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer my_api_key
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '96'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 06 Oct 2020 09:25:05 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Kustomer-Pod:
+      - prod1
+      Timing-Allow-Origin:
+      - "*"
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '996'
+      Cache-Control:
+      - no-cache,private
+      Etag:
+      - W/"60-HutFhcS5uC46icz1LOnmbuNGwCQ"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 c80e676948368625bab1e3de26dbd163.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MXP64-C3
+      X-Amz-Cf-Id:
+      - R_IGXjRfc4qIGQ-0AtGX8Gin-sFYm-NyyUmMBmNZcYxL5aA9Rda09w==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"status":404,"source":{"parameter":"email"},"code":"notfound","title":"Not
+        Found"}]}'
+  recorded_at: Tue, 06 Oct 2020 09:25:05 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/find_by_email_success.yml
+++ b/spec/fixtures/vcr_cassettes/find_by_email_success.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.kustomerapp.com/v1/customers/email=jdoe@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer my_api_key
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Date:
+      - Tue, 06 Oct 2020 09:24:50 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Kustomer-Pod:
+      - prod1
+      Timing-Allow-Origin:
+      - "*"
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '996'
+      Cache-Control:
+      - no-cache,private
+      Etag:
+      - W/"720-u6veyKxVZEvpC0I+MVxlWnhCvC4"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 f6f860dfc55b1909ca7a53c7e5987f4b.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MXP64-C3
+      X-Amz-Cf-Id:
+      - KJha9rfX-k5BFnUJNsUEXKmAs_bGwcnEPDBdQmyUIhCHR2_4VKXImw==
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"customer","id":"the_customer_UUID","attributes":{"name":"","displayName":"johndoe@example.com","displayColor":"blue","displayIcon":"plane","externalId":"6","externalIds":[{"verified":true,"externalId":"6"}],"sharedExternalIds":[],"signedUpAt":"2020-09-28T12:53:04.000Z","username":"johndoe@example.com","emails":[{"type":"home","verified":false,"email":"johndoe@example.com"}],"sharedEmails":[],"phones":[],"sharedPhones":[],"smoochIds":[],"whatsapps":[],"facebookIds":[],"instagramIds":[],"socials":[],"sharedSocials":[],"urls":[],"locations":[],"activeUsers":[],"watchers":[],"recentLocation":{"updatedAt":"2020-09-28T12:53:23.176Z"},"createdAt":"2020-09-28T12:53:23.175Z","updatedAt":"2020-10-01T12:06:20.291Z","modifiedAt":"2020-09-28T12:58:25.555Z","lastActivityAt":"2020-10-01T12:06:20.291Z","lastCustomerActivityAt":"2020-10-01T12:06:20.291Z","deleted":false,"lastMessageIn":{"sentiment":{}},"lastMessageOut":{},"lastMessageUnrespondedTo":{},"lastConversation":{"sentiment":{},"channels":[],"tags":[]},"conversationCounts":{"done":0,"open":0,"snoozed":0,"all":0},"preview":{"$init":true},"tags":[],"sentiment":{},"progressiveStatus":null,"verified":true,"rev":35,"recentItems":[{"meta":{"klassName":"order"},"updatedAt":"2020-10-01T12:06:20.291Z","type":"kobject","id":"5f75c63cd5c0384ad82a17ae"},{"meta":{"klassName":"order"},"updatedAt":"2020-10-01T08:29:42.476Z","type":"kobject","id":"5f7593766df85173b7f96d8a"},{"meta":{"klassName":"order"},"updatedAt":"2020-10-01T08:00:31.521Z","type":"kobject","id":"5f758c9fd5c0381f1a261d61"},{"meta":{"klassName":"order"},"updatedAt":"2020-09-30T16:14:27.048Z","type":"kobject","id":"5f74aee3133e7b0012afee85"}],"satisfactionLevel":{"firstSatisfaction":{"sentByTeams":[]},"lastSatisfaction":{"sentByTeams":[]}},"roleGroupVersions":[],"accessOverride":[]},"relationships":{"messages":{"links":{"self":"/v1/customers/the_customer_UUID/messages"}},"modifiedBy":{"links":{"self":"/v1/users/5f652db64624d3001950caff"},"data":{"type":"user","id":"5f652db64624d3001950caff"}},"org":{"data":{"type":"org","id":"5f651b02c887b30019382410"},"links":{"self":"/v1/orgs/5f651b02c887b30019382410"}},"orders":{"links":{"self":"/v1/customers/the_customer_UUID/klasses/orders"},"meta":{"kobject":true}}},"links":{"self":"/v1/customers/the_customer_UUID"}}}'
+  recorded_at: Tue, 06 Oct 2020 09:24:50 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/update_customer.yml
+++ b/spec/fixtures/vcr_cassettes/update_customer.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.kustomerapp.com/v1/customers/the_customer_UUID
+    body:
+      encoding: UTF-8
+      string: '{"username":"the_new_email@example.com","emails":[{"type":"home","email":"the_new_email@example.com"}],"externalId":"50"}'
+    headers:
+      Authorization:
+      - Bearer my_api_key
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 06 Oct 2020 14:26:53 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Kustomer-Pod:
+      - prod1
+      Timing-Allow-Origin:
+      - "*"
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '999'
+      Cache-Control:
+      - no-cache,private
+      X-Ratelimit-Object-Limit:
+      - '600'
+      X-Ratelimit-Object-Remaining:
+      - '598'
+      Etag:
+      - W/"724-SWcwKKet6Ncooa0+ulISXbd9MmQ"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 7c9f9f67de5f1e5b8c819ce6a8b7f8f4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MXP64-C3
+      X-Amz-Cf-Id:
+      - F7h9KwHDAZPj1UxrsTG_Nsp5jdXvxUfxs7GTkcNZaq_Q96uqjgXFIg==
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"type":"customer","id":"the_customer_UUID","attributes":{"name":"New
+        name","displayName":"New name","displayColor":"pink","displayIcon":"anchor","externalId":"50","externalIds":[{"verified":true,"externalId":"50"}],"sharedExternalIds":[],"username":"the_new_email@example.com","emails":[{"type":"home","verified":false,"email":"the_new_email@example.com"}],"sharedEmails":[],"phones":[],"sharedPhones":[],"smoochIds":[],"whatsapps":[],"facebookIds":[],"instagramIds":[],"socials":[],"sharedSocials":[],"urls":[],"locations":[],"activeUsers":[],"watchers":[],"recentLocation":{"updatedAt":"2020-10-05T16:04:13.305Z"},"createdAt":"2020-10-05T16:04:13.304Z","updatedAt":"2020-10-06T14:26:53.054Z","modifiedAt":"2020-10-06T14:26:53.054Z","lastActivityAt":"2020-10-06T14:26:53.054Z","deleted":false,"lastMessageIn":{"sentiment":{}},"lastMessageOut":{},"lastMessageUnrespondedTo":{},"lastConversation":{"sentiment":{},"channels":[],"tags":[]},"conversationCounts":{"done":0,"open":0,"snoozed":0,"all":0},"preview":{"$init":true},"tags":[],"sentiment":{},"progressiveStatus":null,"verified":true,"rev":3,"recentItems":[],"satisfactionLevel":{"firstSatisfaction":{"sentByTeams":[]},"lastSatisfaction":{"sentByTeams":[]}},"roleGroupVersions":[],"accessOverride":[],"firstName":"New","lastName":"name"},"relationships":{"messages":{"links":{"self":"/v1/customers/the_customer_UUID/messages"}},"createdBy":{"links":{"self":"/v1/users/5f7580902bf93344d8e55eda"},"data":{"type":"user","id":"5f7580902bf93344d8e55eda"}},"modifiedBy":{"links":{"self":"/v1/users/5f7580902bf93344d8e55eda"},"data":{"type":"user","id":"5f7580902bf93344d8e55eda"}},"org":{"data":{"type":"org","id":"5f651b02c887b30019382410"},"links":{"self":"/v1/orgs/5f651b02c887b30019382410"}}},"links":{"self":"/v1/customers/the_customer_UUID"}}}'
+  recorded_at: Tue, 06 Oct 2020 14:26:53 GMT
+recorded_with: VCR 6.0.0

--- a/spec/jobs/solidus_kustomer/create_customer_job_spec.rb
+++ b/spec/jobs/solidus_kustomer/create_customer_job_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe SolidusKustomer::CreateCustomerJob do
+  it 'creates the user on Kustomer' do
+    solidus_kustomer = class_spy(SolidusKustomer)
+    stub_const('SolidusKustomer', solidus_kustomer)
+    user = build_stubbed(:user)
+
+    described_class.perform_now(user)
+
+    expect(solidus_kustomer).to have_received(:create_customer_now).with(user)
+  end
+end

--- a/spec/jobs/solidus_kustomer/update_customer_job_spec.rb
+++ b/spec/jobs/solidus_kustomer/update_customer_job_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe SolidusKustomer::UpdateCustomerJob do
+  it 'updates the user on Kustomer' do
+    solidus_kustomer = class_spy(SolidusKustomer)
+    stub_const('SolidusKustomer', solidus_kustomer)
+    user = build_stubbed(:user)
+
+    described_class.perform_now(user)
+
+    expect(solidus_kustomer).to have_received(:update_customer_now).with(user)
+  end
+end

--- a/spec/lib/solidus_kustomer/client_spec.rb
+++ b/spec/lib/solidus_kustomer/client_spec.rb
@@ -14,6 +14,32 @@ RSpec.describe SolidusKustomer::Client do
     end
   end
 
+  describe '#create_customer' do
+    it 'creates the customer' do
+      user = create(:user_with_addresses, id: 500)
+      kustomer = described_class.new(api_key: 'my_api_key')
+
+      VCR.use_cassette('create_customer') do
+        response = kustomer.create_customer(user)
+        expect(response['attributes']['externalId']).to eq(user.id.to_s)
+      end
+    end
+  end
+
+  describe '#update_customer' do
+    it 'updates the existing customer information on Kustomer' do
+      user = create(:user, kustomer_id: 'the_customer_UUID')
+      kustomer = described_class.new(api_key: 'my_api_key')
+
+      user.update(email: 'the_new_email@example.com')
+
+      VCR.use_cassette('update_customer') do
+        new_customer_data = kustomer.update_customer(user)
+        expect(new_customer_data['attributes']['emails'][0]['email']).to eq('the_new_email@example.com')
+      end
+    end
+  end
+
   describe '#create' do
     context 'with well-formed custom attributes' do
       it 'creates the KObject for the customer' do

--- a/spec/lib/solidus_kustomer/client_spec.rb
+++ b/spec/lib/solidus_kustomer/client_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe SolidusKustomer::Client do
     context 'with well-formed custom attributes' do
       it 'creates the KObject for the customer' do
         kustomer = described_class.new(api_key: 'my_api_key')
-        user = build_stubbed(:user)
+        user = build_stubbed(:user, kustomer_id: 'the_customer_UUID')
         attributes = {
           'orderIdNum' => 1,
           'orderCreatedAt' => Time.zone.now,
           'orderNumberStr' => 'R11111111'
         }
-        allow(kustomer).to receive(:find_customer_by_external_id)
+        allow(kustomer).to receive(:find_customer)
           .with(user)
           .and_return(
             {
@@ -50,11 +50,11 @@ RSpec.describe SolidusKustomer::Client do
     context 'with malformed custom attributes' do
       it 'raises a CreateError' do
         kustomer = described_class.new(api_key: 'my_api_key')
-        user = build_stubbed(:user)
+        user = create(:user)
         attributes = {
           'notAnActualAttribute' => 'foobar'
         }
-        allow(kustomer).to receive(:find_customer_by_external_id)
+        allow(kustomer).to receive(:find_customer)
           .with(user)
           .and_return(
             {
@@ -76,6 +76,44 @@ RSpec.describe SolidusKustomer::Client do
     end
   end
 
+  describe '#find_customer' do
+    context 'when the Spree::User has a kustomer_id' do
+      it 'retrieves the customer via their UUID' do
+        kustomer = described_class.new(api_key: 'my_api_key')
+        user = create(:user, kustomer_id: 'the_customer_UUID')
+        allow(kustomer).to receive(:find_customer_by_uuid)
+
+        kustomer.find_customer(user)
+
+        expect(kustomer).to have_received(:find_customer_by_uuid).with(user.kustomer_id)
+      end
+    end
+
+    context 'when the Spree::User does not have a kustomer_id' do
+      it 'retrieves the customer via their email' do
+        kustomer = described_class.new(api_key: 'my_api_key')
+        user = create(:user)
+        allow(kustomer).to receive(:find_customer_by_email)
+        allow(kustomer).to receive(:find_customer_by_external_id).and_return(nil)
+
+        kustomer.find_customer(user)
+
+        expect(kustomer).to have_received(:find_customer_by_email).with(user.email)
+      end
+
+      it 'retrieves the customer via their external_id when they cannot be found via email' do
+        kustomer = described_class.new(api_key: 'my_api_key')
+        user = create(:user)
+        allow(kustomer).to receive(:find_customer_by_email).and_return(nil)
+        allow(kustomer).to receive(:find_customer_by_external_id)
+
+        kustomer.find_customer(user)
+
+        expect(kustomer).to have_received(:find_customer_by_external_id).with(user.id)
+      end
+    end
+  end
+
   describe '#find_customer_by_external_id' do
     context 'when querying for an existing customer' do
       it 'returns the customer KObject as an hash' do
@@ -83,7 +121,7 @@ RSpec.describe SolidusKustomer::Client do
         user = build_stubbed(:user, id: 6)
 
         VCR.use_cassette('find_success') do
-          customer = kustomer.find_customer_by_external_id(user)
+          customer = kustomer.find_customer_by_external_id(user.id)
           expect(customer).to include(
             'id' => 'the_customer_UUID',
             'type' => 'customer'
@@ -98,7 +136,36 @@ RSpec.describe SolidusKustomer::Client do
         user = build_stubbed(:user, id: 9999)
 
         VCR.use_cassette('find_failure') do
-          customer = kustomer.find_customer_by_external_id(user)
+          customer = kustomer.find_customer_by_external_id(user.id)
+          expect(customer).to eq(nil)
+        end
+      end
+    end
+  end
+
+  describe '#find_customer_by_email' do
+    context 'when querying for an existing customer' do
+      it 'returns the customer KObject as an hash' do
+        kustomer = described_class.new(api_key: 'my_api_key')
+        user = build_stubbed(:user, email: 'jdoe@example.com')
+
+        VCR.use_cassette('find_by_email_success') do
+          customer = kustomer.find_customer_by_email(user.email)
+          expect(customer).to include(
+            'id' => 'the_customer_UUID',
+            'type' => 'customer'
+          )
+        end
+      end
+    end
+
+    context 'when querying for a non existent customer' do
+      it 'returns nil' do
+        kustomer = described_class.new(api_key: 'my_api_key')
+        user = build_stubbed(:user, email: 'not_a_customer@example.com')
+
+        VCR.use_cassette('find_by_email_failure') do
+          customer = kustomer.find_customer_by_email(user.email)
           expect(customer).to eq(nil)
         end
       end

--- a/spec/lib/solidus_kustomer/serializer/user_spec.rb
+++ b/spec/lib/solidus_kustomer/serializer/user_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe SolidusKustomer::Serializer::User do
+  describe '.serialize' do
+    it 'serialize the user data' do
+      user = create(:user)
+
+      expect(described_class.serialize(user)).to be_instance_of(Hash)
+    end
+
+    context 'when the user has addresses' do
+      it 'also serialize their name' do
+        user = create(:user_with_addresses)
+
+        expect(described_class.serialize(user)).to have_key('name')
+      end
+    end
+  end
+end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe Spree::User do
+  describe '#save' do
+    context 'when create_customer_on_creation is set to true' do
+      it 'creates the newly created user on Kustomer' do
+        allow(SolidusKustomer.configuration).to receive(:create_customer_on_user_creation)
+          .and_return(true)
+
+        user = create(:user)
+
+        expect(SolidusKustomer::CreateCustomerJob).to have_been_enqueued.with(user)
+      end
+    end
+
+    context 'when create_customer_on_creation is not set' do
+      it 'does not create the newly created user on Kustomer' do
+        allow(SolidusKustomer.configuration).to receive(:create_customer_on_user_creation)
+          .and_return(nil)
+
+        create(:user)
+
+        expect(SolidusKustomer::CreateCustomerJob).not_to have_been_enqueued
+      end
+    end
+
+    context 'when update_customer_on_update is set to true' do
+      it 'updates the updated user on Kustomer' do
+        allow(SolidusKustomer.configuration).to receive(:update_customer_on_user_update)
+          .and_return(true)
+
+        user = create(:user, email: 'jdoe@example.com')
+        user.update!(email: 'jdoes_new_email@example.com')
+
+        expect(SolidusKustomer::UpdateCustomerJob).to have_been_enqueued.with(user)
+      end
+    end
+
+    context 'when update_customer_on_creation is not set' do
+      it 'does not update the updated user on Kustomer' do
+        allow(SolidusKustomer.configuration).to receive(:update_customer_on_user_update)
+          .and_return(nil)
+
+        user = create(:user, email: 'jdoe@example.com')
+        user.update!(email: 'jdoes_new_email@example.com')
+
+        expect(SolidusKustomer::UpdateCustomerJob).not_to have_been_enqueued
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the core functionality to create and update customer objects on Kustomer.

For accuracy and performance, it also adds a `kustomer_id` column to `Spree::User`, which will be used to not reach to Kustomer's API endpoints to retrieve a user's Kustomer ID every time it's needed. Doing so, this closes #3 .