### PR TITLE
Remove solidus_tracking dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,6 @@ end
 
 gemspec
 
-gem 'solidus_tracking', github: 'solidusio-contrib/solidus_tracking'
-
 # Use a local Gemfile to include development dependencies that might not be
 # relevant for the project or for other contributors, e.g. pry-byebug.
 #

--- a/lib/solidus_kustomer.rb
+++ b/lib/solidus_kustomer.rb
@@ -3,7 +3,6 @@
 require 'httparty'
 require 'solidus_core'
 require 'solidus_support'
-require 'solidus_tracking'
 
 require 'solidus_kustomer/version'
 require 'solidus_kustomer/engine'

--- a/solidus_kustomer.gemspec
+++ b/solidus_kustomer.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_dependency 'httparty', '~> 0.18'
-  spec.add_dependency 'solidus_tracking', '~> 0.0'
 
   spec.add_development_dependency 'solidus_dev_support', '~> 2.0'
   spec.add_development_dependency 'vcr'


### PR DESCRIPTION
Since it's not needed for now, it's better to remove this gem.